### PR TITLE
update install for From changes and docker compose

### DIFF
--- a/developer/codeOrganization.html
+++ b/developer/codeOrganization.html
@@ -193,7 +193,7 @@ title: OED code organization
         </li>
         <li>
             <strong>installOED.sh</strong> sets up OED, either for development for production, creating the database
-            schema and installing dependencies. This is often run using <code>docker-compose up</code> or some variant
+            schema and installing dependencies. This is often run using <code>docker compose up</code> or some variant
             of this.
         </li>
         <li>

--- a/developer/devDetails.html
+++ b/developer/devDetails.html
@@ -8,17 +8,17 @@ title: OED dev details
 
 	<h2 id="fastInstall">Faster OED installation</h2>
 	<p>The easiest way to install OED is to use:
-		<br><code>docker-compose up</code><br>
+		<br><code>docker compose up</code><br>
 		This is equivalent to the full OED install command of
-		<br><code>docker-compose run --service-ports --rm web npm run src/scripts/installOED.sh</code><br>
+		<br><code>docker compose run --service-ports --rm web npm run src/scripts/installOED.sh</code><br>
 	</p>
 
 	<p>When you do this it does a complete npm package install by first removing the node_modules/ directory.
 		Downloading all the needed packages for OED can take many minutes. (<a href="fullInstallOutput.html">full
 			install output</a>) You can avoid the package download by using
-		<br><code>install_args="--keep_node_modules" docker-compose up</code><br>
+		<br><code>install_args="--keep_node_modules" docker compose up</code><br>
 		or the full install of
-		<br><code>docker-compose run --service-ports --rm web npm run src/scripts/installOED.sh --keep_node_modules</code><br>
+		<br><code>docker compose run --service-ports --rm web npm run src/scripts/installOED.sh --keep_node_modules</code><br>
 		It is <strong>very important</strong> to note that this skips updating packages. If you change package.json or
 		package-lock.json directly or by pulling in code that does this, you <strong>should not</strong> use this option
 		but do the full install above after this and then you can use this faster process. If you do not then you will
@@ -29,7 +29,7 @@ title: OED dev details
 	<h2>Rebuild after Docker dependency changes</h2>
 	<p>If a "From" in a Dockerfile is changed, then the version of that software needs to be updated. Docker normally
 		uses its cached version so the update will not happen. To force the update, do
-		<code>docker-compose up --build</code> where you can add other arguments (such as keeping the node modules).
+		<code>docker compose up --build</code> where you can add other arguments (such as keeping the node modules).
 		This should make Docker use what is specified in the Dockerfile. If there are no changes then it will not
 		download a new version of the needed software but it will be a little slower for the checks and potentially
 		creating the container. OED tries to announce to the Developer Discussion board whenever a change is make to a
@@ -66,7 +66,7 @@ title: OED dev details
 	<h2>Stopping OED</h2>
 	<p>If you go to the terminal where OED is running, you can type ^-c (control and letter c) together to stop OED.
 		Note it is best to only do this once since a second time causes a force stop. An alternative is to use
-		<code>docker-compose down</code> in a second terminal that is in the same directory as where the install is
+		<code>docker compose down</code> in a second terminal that is in the same directory as where the install is
 		happening. This can also be useful if you are having an issue with your docker container(s) since it cleans them
 		all up.
 	</p>
@@ -141,19 +141,19 @@ web_1       | [at-loader] Ok, 0.006 sec.
 		run
 		testing (or you want to focus on one test at a time that fails). Running all the tests is much slower than
 		running a single test. Thus, to run a single test, do:
-		<br><code>docker-compose run --rm web npm run testsome -- &lt;first test&gt; [&lt;second test&gt;]
+		<br><code>docker compose run --rm web npm run testsome -- &lt;first test&gt; [&lt;second test&gt;]
 		</code><br>where you replace &lt; xxxx test&gt; with the path to the test you want to run and [ ] indicates this is
 		optional and you can repeat as many times as you want for more tests.
 	</p>
 	<p>For example, to run the web groups test, you would
-		use:<br><code>docker-compose run --rm web npm run testsome -- src/server/test/web/groups.js</code><br>and to run
+		use:<br><code>docker compose run --rm web npm run testsome -- src/server/test/web/groups.js</code><br>and to run
 		the web groups test and the db baselineTests
-		use:<br><code>docker-compose run --rm web npm run testsome -- src/server/test/web/groups.js src/server/test/db/baselineTests.js</code>
+		use:<br><code>docker compose run --rm web npm run testsome -- src/server/test/web/groups.js src/server/test/db/baselineTests.js</code>
 	</p>
 
 	<h2>Accessing the database</h2>
 	<p>You can access the Postgres database that OED uses within the docker container. In a second terminal (the first
-		should have OED running), do <code>docker-compose exec database psql -U oed</code>. You will now be in the
+		should have OED running), do <code>docker compose exec database psql -U oed</code>. You will now be in the
 		Postgres command line for the OED database. Note this is the live system so you can make changes that the
 		running application will see (and damage the information too!). It is assumed you know some SQL and Postgres
 		command line commands if you are doing this. One important one is <code>\q</code> which will get you back to the
@@ -161,12 +161,12 @@ web_1       | [at-loader] Ok, 0.006 sec.
 	<p>There may be times you want to backup/restore the Postgres data for OED. You can do it by</p>
 	<ul>
 		<li>Take a database dump with
-			<code>docker-compose exec database pg_dump -U oed &gt; dump_$(date +%Y-%m-%d"_"%H_%M_%S.sql)</code>
+			<code>docker compose exec database pg_dump -U oed &gt; dump_$(date +%Y-%m-%d"_"%H_%M_%S.sql)</code>
 		</li>
 		<li>Restore a database dump by first copying the dump into the container with
 			<code>docker cp /path/to/dump.sql container_name:/dump.sql</code> and then restoring it into the
 			database
-			with <code>docker-compose exec database psql -U oed -f /dump.sql</code>. The /path/to/dump.sql is the file
+			with <code>docker compose exec database psql -U oed -f /dump.sql</code>. The /path/to/dump.sql is the file
 			with date & time created in the dump step. Note someone should test/see if you
 			really need to put it into the container first.
 		</li>
@@ -186,7 +186,7 @@ web_1       | [at-loader] Ok, 0.006 sec.
 		in OED tests so the change should be fine.</p>
 
 	<h2 id=npmPermission>check permission error</h2>
-	<p>A few developers have reported that when they run <code>docker-compose run --rm web npm run check</code> they get
+	<p>A few developers have reported that when they run <code>docker compose run --rm web npm run check</code> they get
 		an error similar to "Error: EACCES: permission denied, scandir '/root/.npm/_logs". The only current fix is to
 		run outside of docker by doing <code>npm run check</code>. It is believed that this issue is due to doing
 		installs as root and then not being root when inside docker but this is not certain. However, at least one
@@ -202,9 +202,9 @@ web_1       | [at-loader] Ok, 0.006 sec.
 		resolved.) In rare circumstances, you still want to run the OED web container knowing that any
 		operations that touch the database will fail. There is a parameter to the install script that allows this and
 		can be done with:
-		<br><code>install_args="---continue_on_db_error" docker-compose up</code><br>
-		or the full install script (not using docker-compose up) of
-		<br><code>docker-compose run --service-ports --rm web npm run src/scripts/installOED.sh --continue_on_db_error</code><br>
+		<br><code>install_args="---continue_on_db_error" docker compose up</code><br>
+		or the full install script (not using docker compose up) of
+		<br><code>docker compose run --service-ports --rm web npm run src/scripts/installOED.sh --continue_on_db_error</code><br>
 		OED will still try to install the DB, fail and then continue to try to install the web container. You should see
 		the regular messages in the console indicating the web container is running as expected.
 	</p>

--- a/developer/devDetails.html
+++ b/developer/devDetails.html
@@ -26,6 +26,15 @@ title: OED dev details
 			install output</a>)
 	</p>
 
+	<h2>Rebuild after Docker dependency changes</h2>
+	<p>If a "From" in a Dockerfile is changed, then the version of that software needs to be updated. Docker normally
+		uses its cached version so the update will not happen. To force the update, do
+		<code>docker-compose up --build</code> where you can add other arguments (such as keeping the node modules).
+		This should make Docker use what is specified in the Dockerfile. If there are no changes then it will not
+		download a new version of the needed software but it will be a little slower for the checks and potentially
+		creating the container. OED tries to announce to the Developer Discussion board whenever a change is make to a
+		Dockerfile that would require this action.</p>
+
 	<h2 id="resetDB">Resetting the Postgres database</h2>
 	<p>During the initial install of OED, Postgres detects that you have not run before for this install and initializes
 		the database system. It keeps the information in the postgres-data/ directory in the main OED directory. If you

--- a/developer/fullInstallOutput.html
+++ b/developer/fullInstallOutput.html
@@ -21,7 +21,7 @@ title: OED full install
 	</ul>
 
 	<pre>
-$ docker-compose up
+$ docker compose up
 Starting oed_database_1 ... done
 Starting oed_web_1      ... done
 Attaching to oed_database_1, oed_web_1

--- a/developer/gettingStarted.html
+++ b/developer/gettingStarted.html
@@ -33,7 +33,7 @@ title: OED developer startup
         </li>
         <li>OED uses the Docker container system to run the software so you need to <a
                 href="https://www.docker.com/products/docker-desktop" rel="noopener noreferrer">download</a> and install
-            Docker. (You need both Docker and docker-compose but you generally get those together during the
+            Docker. (You need both Docker and docker compose but you generally get those together during the
             install.) This
             has the advantage that our configuration
             files for Docker can get any needed software and also means we do not modify your normal system since the
@@ -63,10 +63,10 @@ title: OED developer startup
                             might do<br><code>cd /home/username/projects/OED</code><br>if you cloned OED in the
                             /home/username/projects/
                             directory.</li>
-                        <li><code>docker-compose up</code><br>This will run the entire OED install process. Note that on
+                        <li><code>docker compose up</code><br>This will run the entire OED install process. Note that on
                             some systems (mostly some Linux systems), depending on how you installed Docker, you may get
                             a
-                            permission error so you will need to do:<br><code>sudo docker-compose up</code><br>which
+                            permission error so you will need to do:<br><code>sudo docker compose up</code><br>which
                             runs
                             the process with root privileges. If this is
                             the case then you need to do sudo before all docker commands on your system.<br>

--- a/developer/noNPMInstallOutput.html
+++ b/developer/noNPMInstallOutput.html
@@ -23,7 +23,7 @@ title: OED quick install
 	</ul>
 
 	<pre>
-$  install_args="--keep_node_modules" docker-compose up
+$  install_args="--keep_node_modules" docker compose up
 Starting oed_database_1 ... done
 Starting oed_web_1      ... done
 Attaching to oed_database_1, oed_web_1

--- a/developer/npm.html
+++ b/developer/npm.html
@@ -6,7 +6,7 @@ title: OED npm scripts
 	<h1>OED NPM Scripts</h1>
 
 	<p>OED has many scripts to support its use for development and sometimes in production settings. These can be
-		run by executing <code>npm run [SCRIPT]</code> in the <code>web</code> Docker-Compose
+		run by executing <code>npm run [SCRIPT]</code> in the <code>web</code> docker compose
 		service
 		(e.g. <code>docker compose run --rm web npm run [SCRIPT] [args]</code>).</p>
 	<p>For non-Docker installs (not normally the case and assumes you have npm on your system), simply issue

--- a/developer/pr.html
+++ b/developer/pr.html
@@ -26,9 +26,9 @@ title: OED PRs
 			has the needed license at the top and that TypeScript is used where expected. You will likely find it easier
 			if
 			you run this check early to find any issues so you don't repeat them many times. The checks are run in a
-			terminal. The safest way is to do it inside Docker (by using docker-compose). To
-			do this do (from the main OED directory as needed for all docker-compose commands):
-			<br><code>docker-compose run --rm web npm run check</code><br>
+			terminal. The safest way is to do it inside Docker (by using docker compose). To
+			do this do (from the main OED directory as needed for all docker compose commands):
+			<br><code>docker compose run --rm web npm run check</code><br>
 			You can run the check outside of Docker with:<br><code>npm run check</code><br>where you need to have npm
 			installed on your system outside the Docker OED system. Note that the checks use certain Unix commands that
 			may not run or may not run as expected on your system so even though this is faster we recommend doing it
@@ -38,7 +38,7 @@ title: OED PRs
 		</li>
 		<li>Run our code checks. These run all the test cases to verify the code is running correctly. It is similar to
 			running lint where you use:
-			<br><code>docker-compose run --rm web npm run test</code><br>
+			<br><code>docker compose run --rm web npm run test</code><br>
 			This can take several minutes. A summary will be given at the bottom. If you see any errors then they should
 			be checked out. Let us know if you need help. You will do the same command to check any new tests you add.
 			Please note that it is difficult to run the tests outside Docker (with the full OED install) so you should

--- a/developer/wslSteps.html
+++ b/developer/wslSteps.html
@@ -20,7 +20,7 @@ title: Steps for WSL
             there as well. The information below assumes you have done this and the commands given are run in a Linux
             shell.</strong></p>
 
-    <h1>Errors running <code>docker-compose up</code> might throw:</h1>
+    <h1>Errors running <code>docker compose up</code> might throw:</h1>
     <ol>
         <li>
             <h2><code>FileNotFoundError: [Errno 2] No such file or directory</code></h2><br>
@@ -37,11 +37,11 @@ title: Steps for WSL
             while for the npm install to finish but wait and hopefully this will happen. You will likely then get a
             message
             about trying to start to database but nothing after that one line. At this point, stop the install (a
-            <strong>single ^c</strong> (control and letter c) or <code>docker-compose down</code> in a second terminal
+            <strong>single ^c</strong> (control and letter c) or <code>docker compose down</code> in a second terminal
             where it is in the same
             OED
             directory as the install is happening). You should now be back at the command line. Do
-            <code>install_args="--keep_node_modules" docker-compose up</code> which will try the install again but keep
+            <code>install_args="--keep_node_modules" docker compose up</code> which will try the install again but keep
             the
             node modules (node_modules/ directory) and the Postgres installation (in postgres-data/ directory). Normally
             this will complete the installation fairly quickly without further issues. For now, we encourage you to do

--- a/help/v0.8.0/adminInstallOutput.html
+++ b/help/v0.8.0/adminInstallOutput.html
@@ -5,7 +5,7 @@ title: OED production install
 <div>
     <h1>Production Install Output</h1>
     <p>When you install OED for production you will get output similar to what is below (assuming this is the first time
-        you are running <code>docker compose up</code>). Please note:</p>
+        you are running <code>docker-compose up</code>). Please note:</p>
     <ul>
         <li>This output was created on 17 Jan 2022 using OED v0.8.0. The exact output will vary with
             machine type and changes to OED.</li>
@@ -19,7 +19,7 @@ title: OED production install
     </ul>
 
     <pre>
-        $ docker compose up
+        $ docker-compose up
         [+] Running 2/2
          ⠿ Container oed-database-1  Created                                                                                        0.0s
          ⠿ Container oed-web-1       Recreated                                                                                      0.2s

--- a/help/v0.8.0/adminInstallOutput.html
+++ b/help/v0.8.0/adminInstallOutput.html
@@ -5,7 +5,7 @@ title: OED production install
 <div>
     <h1>Production Install Output</h1>
     <p>When you install OED for production you will get output similar to what is below (assuming this is the first time
-        you are running <code>docker-compose up</code>). Please note:</p>
+        you are running <code>docker compose up</code>). Please note:</p>
     <ul>
         <li>This output was created on 17 Jan 2022 using OED v0.8.0. The exact output will vary with
             machine type and changes to OED.</li>
@@ -19,7 +19,7 @@ title: OED production install
     </ul>
 
     <pre>
-        $ docker-compose up
+        $ docker compose up
         [+] Running 2/2
          ⠿ Container oed-database-1  Created                                                                                        0.0s
          ⠿ Container oed-web-1       Recreated                                                                                      0.2s

--- a/help/v0.8.0/adminInstallation.html
+++ b/help/v0.8.0/adminInstallation.html
@@ -185,7 +185,8 @@ title: OED installation
             to not to try.
         </li>
         <li>Make sure you are in the root OED directory (where the README.md file is located).</li>
-        <li>Install OED on the server by doing <code>docker compose up</code>. This will get all the needed software
+        <li>Install OED on the server by doing <code>docker-compose up</code>. (On older versions of Docker you must do
+            <code>docker-compose up</code>.) This will get all the needed software
             including Postgres, all node packages and then installs all the needed software. This can take from
             a minute
             to 10+ minutes depending on the speed of your server. You will see a lot
@@ -275,7 +276,7 @@ Password: passwordYouChoose
         </li>
         <li>Shut down OED. You will soon be setting up OED to run as a service so you want to stop the one running in
             the
-            terminal. In the terminal where you started OED (with <code>docker compose up</code>),
+            terminal. In the terminal where you started OED (with <code>docker-compose up</code>),
             do "^c" to shut down OED. Be a little patient since doing a second "^c" will cause a rapid stop of docker
             without the normal cleanup.</li>
         <li>In the following steps you need to know the root directory of OED. In the terminal where you are in the OED
@@ -394,7 +395,7 @@ Password: passwordYouChoose
         skips doing it again to save time. However you can force OED to do the node install by going to the root OED
         directory and deleting the node_modules directory with: <code>rm -rf node_modules/</code>. Make sure OED is not
         running (see stopping the service above) before you do this since it will break the application. Redoing the OED
-        install with <code>docker compose up</code>
+        install with <code>docker-compose up</code>
         will recreate this directory.</p>
 
 </div>

--- a/help/v0.8.0/adminInstallation.html
+++ b/help/v0.8.0/adminInstallation.html
@@ -185,7 +185,7 @@ title: OED installation
             to not to try.
         </li>
         <li>Make sure you are in the root OED directory (where the README.md file is located).</li>
-        <li>Install OED on the server by doing <code>docker-compose up</code>. (On older versions of Docker you must do
+        <li>Install OED on the server by doing <code>docker compose up</code>. (On older versions of Docker you must do
             <code>docker-compose up</code>.) This will get all the needed software
             including Postgres, all node packages and then installs all the needed software. This can take from
             a minute
@@ -276,7 +276,7 @@ Password: passwordYouChoose
         </li>
         <li>Shut down OED. You will soon be setting up OED to run as a service so you want to stop the one running in
             the
-            terminal. In the terminal where you started OED (with <code>docker-compose up</code>),
+            terminal. In the terminal where you started OED (with <code>docker compose up</code>),
             do "^c" to shut down OED. Be a little patient since doing a second "^c" will cause a rapid stop of docker
             without the normal cleanup.</li>
         <li>In the following steps you need to know the root directory of OED. In the terminal where you are in the OED
@@ -395,7 +395,7 @@ Password: passwordYouChoose
         skips doing it again to save time. However you can force OED to do the node install by going to the root OED
         directory and deleting the node_modules directory with: <code>rm -rf node_modules/</code>. Make sure OED is not
         running (see stopping the service above) before you do this since it will break the application. Redoing the OED
-        install with <code>docker-compose up</code>
+        install with <code>docker compose up</code>
         will recreate this directory.</p>
 
 </div>

--- a/help/v0.8.0/adminUpgrading.html
+++ b/help/v0.8.0/adminUpgrading.html
@@ -58,14 +58,14 @@ title: OED upgrades
 			in the terminal, OED will be doing the install and may take a while to complete without showing any output.
 		</li>
 		<li>Sometimes OED needs to upgrade the images/containers used in Docker. This can be accomplished by doing:
-			<code>docker-compose up --build</code>. This is the same step as the original build from
+			<code>docker compose up --build</code>. This is the same step as the original build from
 			the first OED installation with an added argument and can take a little while. See the <a
 				href="adminInstallation.html">OED
 				installation page</a> for further information. Once complete, you should then be able to access OED via
 			a web browser
 			to see it is running properly and has all the data and settings you had before the upgrade. Doing it outside
 			the Unix service makes it easier to see any issues during the build steps. Once you complete this step then
-			do "^c" in the terminal where you did the <code>docker-compose up</code> to shut down OED. Be a little
+			do "^c" in the terminal where you did the <code>docker compose up</code> to shut down OED. Be a little
 			patient since doing a second "^c" will cause a rapid stop of docker without the normal cleanup.
 		</li>
 		<li>Restart the OED app and service with: <code>systemctl start oed.service</code>.</li>

--- a/help/v0.8.0/adminUpgrading.html
+++ b/help/v0.8.0/adminUpgrading.html
@@ -57,13 +57,15 @@ title: OED upgrades
 			<code>[at-loader] Using typescript@3.5.3 from typescript and "tsconfig.json" from /usr/src/app/tsconfig.json.</code>
 			in the terminal, OED will be doing the install and may take a while to complete without showing any output.
 		</li>
-		<li>Though not technically necessary, it isn't a bad idea to manually bring up OED with:
-			<code>docker compose up</code>. This is the same step as the original build from
-			the first OED installation and can take a little while. See the <a href="adminInstallation.html">OED
-				installation page</a> for further information. You should then be able to access OED via a web browser
+		<li>Sometimes OED needs to upgrade the images/containers used in Docker. This can be accomplished by doing:
+			<code>docker-compose up --build</code>. This is the same step as the original build from
+			the first OED installation with an added argument and can take a little while. See the <a
+				href="adminInstallation.html">OED
+				installation page</a> for further information. Once complete, you should then be able to access OED via
+			a web browser
 			to see it is running properly and has all the data and settings you had before the upgrade. Doing it outside
 			the Unix service makes it easier to see any issues during the build steps. Once you complete this step then
-			do "^c" in the terminal where you did the <code>docker compose up</code> to shut down OED. Be a little
+			do "^c" in the terminal where you did the <code>docker-compose up</code> to shut down OED. Be a little
 			patient since doing a second "^c" will cause a rapid stop of docker without the normal cleanup.
 		</li>
 		<li>Restart the OED app and service with: <code>systemctl start oed.service</code>.</li>


### PR DESCRIPTION
An upcoming PR will update node. During that process it was noticed that you need to start OED differently when a From is changed in a Dockerfile. This updates the web pages for this.

docker-compose has been replaced with docker compose since it has been around for a while.